### PR TITLE
Fix Game constructor params: transparent, antialias

### DIFF
--- a/lib/core/game.dart
+++ b/lib/core/game.dart
@@ -83,7 +83,7 @@ class Game {
     }
   }
 
-  Game([num width = 800, num height = 600, int renderer = AUTO, String parent = '', State state, this.transparent, this.antialias, this.physicsConfig]) {
+  Game([num width = 800, num height = 600, int renderer = AUTO, String parent = '', State state, transparent, antialias, this.physicsConfig]) {
 
     GAMES.add(this);
     /**


### PR DESCRIPTION
I found an issue where the transparent and antialias params passed to new Game were not being set:

new Game(w, h, CANVAS, '', state, true);

then check in the state.create method, and find that the transparent field is set to false.

I found the cause to be the constructor parameter list usage of 'this.' conflicting with the constructor's later initialization of the same field.